### PR TITLE
jupiter: add fallback to searchToken in getTokenPrices

### DIFF
--- a/toolkits/jupiter/api.ts
+++ b/toolkits/jupiter/api.ts
@@ -8,7 +8,27 @@ export async function getTokenPrices(inputTokenAddress: string, outputTokenAddre
     
     return { inputPrice, outputPrice };
   } catch (error) {
-    throw new Error(`Failed to fetch token prices: ${error}`);
+    // If the primary API fails completely, try searchToken as fallback
+    try {
+      const tokenAddresses = [inputTokenAddress, outputTokenAddress];
+      const searchResults = await searchToken(tokenAddresses.join(','));
+      
+      let inputPrice = 0;
+      let outputPrice = 0;
+      
+      for (const token of searchResults) {
+        if (token.id === inputTokenAddress) {
+          inputPrice = token.usdPrice || 0;
+        }
+        if (token.id === outputTokenAddress) {
+          outputPrice = token.usdPrice || 0;
+        }
+      }
+      
+      return { inputPrice, outputPrice };
+    } catch (searchError) {
+      throw new Error(`Failed to fetch token prices: ${error}. Fallback also failed: ${searchError}`);
+    }
   }
 }
 


### PR DESCRIPTION
- When primary price API fails, fallback to searchToken Ultra API
- Extract prices using token.usdPrice field for compatibility
- Provide detailed error messages for both API failures

🤖 Generated with [Claude Code](https://claude.ai/code)